### PR TITLE
TERF-76: Fix cluster version parsing

### DIFF
--- a/metadata/api_versions.go
+++ b/metadata/api_versions.go
@@ -41,7 +41,7 @@ func MaxVastVerion() string {
 	return last.GetVastVersion()
 }
 
-func MinVastVerion() string {
+func MinVastVersion() string {
 	/*
 	   This will return minimal version , however unlike max where we know that at least
 	   the latest the build_version is supported , we can never know the version, so we simply return
@@ -59,8 +59,8 @@ func FindVastVersion(ver string) string {
 			return api_verions[i].GetVastVersion()
 		} else if c == -1 {
 			if i == 0 {
-				//Version is smaller than the miniaml version
-				return MinVastVerion()
+				//Version is smaller than the minimal version
+				return MinVastVersion()
 			}
 			/*
 			   If current version is smaller than this version and the index is not 0

--- a/metadata/api_versions.go
+++ b/metadata/api_versions.go
@@ -1,7 +1,7 @@
 package metadata
 
 import (
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 )
 
 func extractVersion(v *version.Version, e error) version.Version {
@@ -12,8 +12,8 @@ func extractVersion(v *version.Version, e error) version.Version {
 }
 
 type VastVersionStruct struct {
-	Ver      version.Version
-	Vast_ver string
+	Ver         version.Version
+	VastVersion string
 }
 
 func (v *VastVersionStruct) GetVersion() *version.Version {
@@ -21,15 +21,15 @@ func (v *VastVersionStruct) GetVersion() *version.Version {
 }
 
 func (v *VastVersionStruct) GetVastVersion() string {
-	return v.Vast_ver
+	return v.VastVersion
 }
 
-var api_versions []VastVersionStruct = []VastVersionStruct{
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("4.6.0")), Vast_ver: "v2"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("4.7.0")), Vast_ver: "v3"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.0.0")), Vast_ver: "v4"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.1.0")), Vast_ver: "v5"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.2.0")), Vast_ver: "v5"},
+var apiVersions = []VastVersionStruct{
+	{Ver: extractVersion(version.NewVersion("4.6.0")), VastVersion: "v2"},
+	{Ver: extractVersion(version.NewVersion("4.7.0")), VastVersion: "v3"},
+	{Ver: extractVersion(version.NewVersion("5.0.0")), VastVersion: "v4"},
+	{Ver: extractVersion(version.NewVersion("5.1.0")), VastVersion: "v5"},
+	{Ver: extractVersion(version.NewVersion("5.2.0")), VastVersion: "v5"},
 }
 
 func MaxVastVersion() string {
@@ -38,7 +38,7 @@ func MaxVastVersion() string {
 	   This is for situations where we have a cluster version grater than our
 	   build version.
 	*/
-	last := api_versions[len(api_versions)-1]
+	last := apiVersions[len(apiVersions)-1]
 	return last.GetVastVersion()
 }
 
@@ -54,10 +54,10 @@ func MinVastVersion() string {
 func FindVastVersion(ver string) string {
 	newVersion, err := version.NewVersion(ver)
 	_clusterVersion := extractVersion(newVersion, err)
-	for i := range api_versions {
-		c := _clusterVersion.Compare(api_versions[i].GetVersion())
+	for i := range apiVersions {
+		c := _clusterVersion.Compare(apiVersions[i].GetVersion())
 		if c == 0 {
-			return api_versions[i].GetVastVersion()
+			return apiVersions[i].GetVastVersion()
 		} else if c == -1 {
 			if i == 0 {
 				//Version is smaller than the minimal version
@@ -67,7 +67,7 @@ func FindVastVersion(ver string) string {
 			   If current version is smaller than this version and the index is not 0
 			   than the maxversion is the previous version
 			*/
-			return api_versions[i-1].GetVastVersion()
+			return apiVersions[i-1].GetVastVersion()
 		}
 	}
 	/*

--- a/metadata/api_versions.go
+++ b/metadata/api_versions.go
@@ -30,7 +30,7 @@ var api_versions []VastVersionStruct = []VastVersionStruct{
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.0.0")), Vast_ver: "v4"},
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.1.0")), Vast_ver: "v5"},
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.2.0")), Vast_ver: "v5"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.3.0")), Vast_ver: "v6"}}
+}
 
 func MaxVastVersion() string {
 	/*

--- a/metadata/api_versions.go
+++ b/metadata/api_versions.go
@@ -24,20 +24,21 @@ func (v *VastVersionStruct) GetVastVersion() string {
 	return v.Vast_ver
 }
 
-var api_verions []VastVersionStruct = []VastVersionStruct{
+var api_versions []VastVersionStruct = []VastVersionStruct{
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("4.6.0")), Vast_ver: "v2"},
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("4.7.0")), Vast_ver: "v3"},
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.0.0")), Vast_ver: "v4"},
 	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.1.0")), Vast_ver: "v5"},
-	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.2.0")), Vast_ver: "v5"}}
+	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.2.0")), Vast_ver: "v5"},
+	VastVersionStruct{Ver: extractVersion(version.NewVersion("5.3.0")), Vast_ver: "v6"}}
 
-func MaxVastVerion() string {
+func MaxVastVersion() string {
 	/*
-	   return the latest avaliable supported, vast version
+	   return the latest available supported, vast version
 	   This is for situations where we have a cluster version grater than our
 	   build version.
 	*/
-	last := api_verions[len(api_verions)-1]
+	last := api_versions[len(api_versions)-1]
 	return last.GetVastVersion()
 }
 
@@ -51,12 +52,12 @@ func MinVastVersion() string {
 }
 
 func FindVastVersion(ver string) string {
-	v, e := version.NewVersion(ver)
-	cluster_version := extractVersion(v, e)
-	for i := range api_verions {
-		c := cluster_version.Compare(api_verions[i].GetVersion())
+	newVersion, err := version.NewVersion(ver)
+	_clusterVersion := extractVersion(newVersion, err)
+	for i := range api_versions {
+		c := _clusterVersion.Compare(api_versions[i].GetVersion())
 		if c == 0 {
-			return api_verions[i].GetVastVersion()
+			return api_versions[i].GetVastVersion()
 		} else if c == -1 {
 			if i == 0 {
 				//Version is smaller than the minimal version
@@ -66,11 +67,11 @@ func FindVastVersion(ver string) string {
 			   If current version is smaller than this version and the index is not 0
 			   than the maxversion is the previous version
 			*/
-			return api_verions[i-1].GetVastVersion()
+			return api_versions[i-1].GetVastVersion()
 		}
 	}
 	/*
 	   Reaching to this stage means that the cluster version is bigger than out build (last) version
 	*/
-	return MaxVastVerion()
+	return MaxVastVersion()
 }

--- a/metadata/build-verions.go
+++ b/metadata/build-verions.go
@@ -4,8 +4,8 @@ import (
 	version "github.com/hashicorp/go-version"
 )
 
-var build_version, _ = version.NewVersion("5.2.0")
-var min_version, _ = version.NewVersion("5.0.0")
+var buildVersion, _ = version.NewVersion("5.2.0")
+var minVersion, _ = version.NewVersion("5.0.0")
 
 const (
 	CLUSTER_VERSION_EQUALS int = 0
@@ -14,16 +14,16 @@ const (
 )
 
 func GetBuildVersion() version.Version {
-	return *build_version
+	return *buildVersion
 }
 
 func ClusterVersionCompare() int {
-	return build_version.Compare(cluster_version)
+	return buildVersion.Compare(clusterVersion)
 
 }
 
 func GetMinVersion() version.Version {
-	return *min_version
+	return *minVersion
 }
 
 func BuildVersionString() string {
@@ -33,6 +33,6 @@ func BuildVersionString() string {
 }
 
 func IsLowerThanMinVersion() bool {
-	return cluster_version.LessThan(min_version)
+	return clusterVersion.LessThan(minVersion)
 
 }

--- a/metadata/build-verions_test.go
+++ b/metadata/build-verions_test.go
@@ -1,10 +1,10 @@
 package metadata_test
 
 import (
-	"github.com/vast-data/terraform-provider-vastdata/metadata"
 	version "github.com/hashicorp/go-version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/vast-data/terraform-provider-vastdata/metadata"
 )
 
 var _ = Describe("Build Version Testing", func() {

--- a/metadata/cluster-version.go
+++ b/metadata/cluster-version.go
@@ -2,28 +2,16 @@ package metadata
 
 import (
 	version "github.com/hashicorp/go-version"
-	"strconv"
 	"strings"
 )
 
 var clusterVersion, _ = version.NewVersion("0.0.0")
 
-// SanitizeVersion truncates segments of Cluster Version so that each segment can fit within int64.
-// This is needed, because hashicorp's go-version package parses each segment into int64.
+// SanitizeVersion truncates all segments of Cluster Version above core (x.y.z)
 func SanitizeVersion(version string) (string, bool) {
 	segments := strings.Split(version, ".")
-	truncated := false
-	for i, segment := range segments {
-		for {
-			if _, err := strconv.ParseInt(segment, 10, 64); err == nil {
-				break
-			}
-			segment = segment[1:]
-			truncated = true
-		}
-		segments[i] = segment
-	}
-	return strings.Join(segments, "."), truncated
+	truncated := len(segments) > 3
+	return strings.Join(segments[:3], "."), truncated
 }
 
 func UpdateClusterVersion(v string) error {

--- a/metadata/cluster-version.go
+++ b/metadata/cluster-version.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var cluster_version, _ = version.NewVersion("0.0.0")
+var clusterVersion, _ = version.NewVersion("0.0.0")
 
 // SanitizeVersion truncates segments of Cluster Version so that each segment can fit within int64.
 // This is needed, because hashicorp's go-version package parses each segment into int64.
@@ -27,17 +27,17 @@ func SanitizeVersion(version string) (string, bool) {
 }
 
 func UpdateClusterVersion(v string) error {
-	_cluster_version, err := version.NewVersion(v)
+	newVersion, err := version.NewVersion(v)
 	if err != nil {
 		return err
 	}
 	//We only work with core version//
-	cluster_version = _cluster_version.Core()
+	clusterVersion = newVersion.Core()
 	return nil
 }
 
 func GetClusterVersion() version.Version {
-	return *cluster_version
+	return *clusterVersion
 }
 
 func ClusterVersionString() string {

--- a/metadata/cluster-version.go
+++ b/metadata/cluster-version.go
@@ -2,9 +2,29 @@ package metadata
 
 import (
 	version "github.com/hashicorp/go-version"
+	"strconv"
+	"strings"
 )
 
 var cluster_version, _ = version.NewVersion("0.0.0")
+
+// SanitizeVersion truncates segments of Cluster Version so that each segment can fit within int64.
+// This is needed, because hashicorp's go-version package parses each segment into int64.
+func SanitizeVersion(version string) (string, bool) {
+	segments := strings.Split(version, ".")
+	truncated := false
+	for i, segment := range segments {
+		for {
+			if _, err := strconv.ParseInt(segment, 10, 64); err == nil {
+				break
+			}
+			segment = segment[1:]
+			truncated = true
+		}
+		segments[i] = segment
+	}
+	return strings.Join(segments, "."), truncated
+}
 
 func UpdateClusterVersion(v string) error {
 	_cluster_version, err := version.NewVersion(v)

--- a/metadata/cluster_config.go
+++ b/metadata/cluster_config.go
@@ -1,12 +1,12 @@
 package metadata
 
-var cluster_config map[string]string = map[string]string{}
+var clusterConfig = map[string]string{}
 
 func SetClusterConfig(key, value string) {
-	cluster_config[key] = value
+	clusterConfig[key] = value
 }
 
 func GetClusterConfig(key string) (string, bool) {
-	value, exists := cluster_config[key]
+	value, exists := clusterConfig[key]
 	return value, exists
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -116,9 +116,8 @@ func providerConfigure(ctx context.Context, r *schema.ResourceData) (interface{}
 	tflog.Info(ctx, fmt.Sprintf("Cluster version found %s", clusterVersion))
 	clusterVersion, truncated := metadata.SanitizeVersion(clusterVersion)
 	if truncated {
-		tflog.Info(ctx, fmt.Sprintf("Cluster version truncated (from the left) to: %s", clusterVersion))
+		tflog.Info(ctx, fmt.Sprintf("Cluster version truncated to: %s", clusterVersion))
 	}
-
 	err = metadata.UpdateClusterVersion(clusterVersion)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -25,21 +25,21 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    false,
 				Required:    true,
-				Description: `The VastData Cluster hostname/address , if environmnet variable VASTDATA_HOST exists it will be used`,
+				Description: `The VastData Cluster hostname/address , if environment variable VASTDATA_HOST exists it will be used`,
 				DefaultFunc: schema.EnvDefaultFunc("VASTDATA_HOST", nil),
 			},
 			"port": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Required:    false,
-				Description: `The server API port (Default is 443) ,if environmnet variable VASTDATA_PORT exists it will be used`,
+				Description: `The server API port (Default is 443) ,if environment variable VASTDATA_PORT exists it will be used`,
 				DefaultFunc: schema.EnvDefaultFunc("VASTDATA_PORT", 443),
 			},
 			"skip_ssl_verify": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Required:    false,
-				Description: `A boolean representing should SSL certificate be verified (Default is False) , if environmnet variable VASTDATA_VERIFY_SSL exists it will be used`,
+				Description: `A boolean representing should SSL certificate be verified (Default is False) , if environment variable VASTDATA_VERIFY_SSL exists it will be used`,
 				DefaultFunc: schema.EnvDefaultFunc("VASTDATA_VERIFY_SSL", false),
 			},
 
@@ -48,7 +48,7 @@ func Provider() *schema.Provider {
 				Optional:    false,
 				Required:    true,
 				Sensitive:   true,
-				Description: `The VastData Cluster username, if environmnet variable VASTDATA_CLUSTER_USERNAME exists it will be used`,
+				Description: `The VastData Cluster username, if environment variable VASTDATA_CLUSTER_USERNAME exists it will be used`,
 				DefaultFunc: schema.EnvDefaultFunc("VASTDATA_CLUSTER_USERNAME", nil),
 			},
 			"password": &schema.Schema{
@@ -56,7 +56,7 @@ func Provider() *schema.Provider {
 				Optional:    false,
 				Required:    true,
 				Sensitive:   true,
-				Description: `The VastData Cluster password, if environmnet variable VASTDATA_CLUSTER_PASSWORD exists it will be used`,
+				Description: `The VastData Cluster password, if environment variable VASTDATA_CLUSTER_PASSWORD exists it will be used`,
 				DefaultFunc: schema.EnvDefaultFunc("VASTDATA_CLUSTER_PASSWORD", nil),
 			},
 			"version_validation_mode": &schema.Schema{
@@ -65,10 +65,10 @@ func Provider() *schema.Provider {
 				Required:  false,
 				Sensitive: false,
 				Description: `The version validation mode to use , version validation checks if a resource request will work with the current cluster version
-Depanding on the value the operation will abort from happening if according to the version the operation might not work.
-2 options are valid for this attribute
+Depending on the value the operation will abort from happening if according to the version the operation might not work.
+2 options are valid for this attribute:
 1. strict - abort the operation before it starts
-2. warn - Just issue a warnning `,
+2. warn - Just issue a warning`,
 				DefaultFunc:  schema.EnvDefaultFunc("VERSION_VALIDATION_MODE", "warn"),
 				ValidateFunc: validation.StringInSlice([]string{"warn", "strict"}, true),
 			},
@@ -99,7 +99,7 @@ func providerConfigure(ctx context.Context, r *schema.ResourceData) (interface{}
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Unable to start a session to the vastdata cluser",
+			Summary:  "Unable to start a session to the vastdata cluster",
 			Detail:   err.Error(),
 		})
 		return client, diags
@@ -123,7 +123,7 @@ func providerConfigure(ctx context.Context, r *schema.ResourceData) (interface{}
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Error occured while updating cluster version",
+			Summary:  "Error occurred while updating cluster version",
 			Detail:   err.Error(),
 		})
 		return client, diags


### PR DESCRIPTION
Fix cluster version parsing by removing anything that's not core. We only need core part of the version to make our assesments.